### PR TITLE
NURESTFetcher: currentResponseCount to keep count of total objects fetched already

### DIFF
--- a/NURESTFetcher.j
+++ b/NURESTFetcher.j
@@ -34,6 +34,7 @@ NURESTFetcherPageSize = 50;
 @implementation NURESTFetcher : CPObject
 {
     CPNumber            _currentPage            @accessors(property=currentPage);
+    CPNumber            _currentResponseCount   @accessors(property=currentResponseCount);
     CPNumber            _currentTotalCount      @accessors(property=currentTotalCount);
     CPString            _currentOrderedBy       @accessors(property=currentOrderedBy);
     CPString            _queryString            @accessors(property=queryString);
@@ -284,6 +285,7 @@ NURESTFetcherPageSize = 50;
     {
         _currentTotalCount = 0;
         _currentPage       = 0;
+        _currentResponseCount = 0;
         _currentOrderedBy  = @"";
         fetchedObjects     = nil;
     }
@@ -296,6 +298,8 @@ NURESTFetcherPageSize = 50;
 
         var JSONObject = [[_currentConnection responseData] JSONObject];
 
+        _currentResponseCount += [JSONObject count];
+        
         for (var i = 0, c = [JSONObject count]; i < c; i++)
         {
             var newObject = [self newManagedObject];


### PR DESCRIPTION
NURESTFetcher: currentResponseCount to keep count of total objects fetched already

Until now count of _contents was being used to determine current count, and this was being used to determine current page number fetched.
But this does not work in associators. 
commit is set as false in NURESTConnection based on NUObjectsChooser.commitFetchedObjects. 
Because of this, _contents will not be updated when commit is false.

Peer PR: https://github.com/nuagenetworks/nukit/pull/22
Ticket: http://mvjira.mv.usa.alcatel.com/browse/VSD-22759