### PR TITLE
pagination fix

### DIFF
--- a/NURESTFetcher.j
+++ b/NURESTFetcher.j
@@ -76,8 +76,11 @@ NURESTFetcherPageSize = 50;
 
 - (id)init
 {
-    if (self = [super init])
+    if (self = [super init]) 
+    {
         _contents = [];
+        _currentResponseCount = 0;
+    }
 
     return self;
 }
@@ -155,6 +158,7 @@ NURESTFetcherPageSize = 50;
 {
     [self _resetLastConnectionInformation];
     [_contents removeAllObjects];
+    _currentResponseCount = 0;
 }
 
 - (id)_RESTFilterFromFilter:(id)aFilter masterFilter:(id)aMasterFilter


### PR DESCRIPTION
_currentResponseCount is used in NUModule to compute page number.
I had introduced _currentResponseCount in https://github.com/nuagenetworks/objj-bambou/pull/4

Bug: This count was not being reset to 0 in fetcher init. Because of this, page number computation in NUModule goes wrong.

Fix: Reinitialize _currentResponseCount to 0 in init and flush